### PR TITLE
Fix urls so they work in 1.5

### DIFF
--- a/contacts/templates/contact_list.html
+++ b/contacts/templates/contact_list.html
@@ -3,9 +3,9 @@
 <ul>
   {% for contact in object_list %}
     <li><a href="{{ contact.get_absolute_url }}">{{ contact }}</a>
-      (<a href="{% url contacts-edit pk=contact.id %}">edit</a>)
+      (<a href="{% url "contacts-edit" pk=contact.id %}">edit</a>)
     </li>
   {% endfor %}
 </ul>
 
-<a href="{% url contacts-new %}">add contact</a>
+<a href="{% url "contacts-new" %}">add contact</a>

--- a/contacts/templates/delete_contact.html
+++ b/contacts/templates/delete_contact.html
@@ -2,9 +2,9 @@
 
 <p>Are you sure you want to delete the contact {{ contact }}?</p>
 
-<form action="{% url contacts-delete pk=contact.id %}" method="POST">
+<form action="{% url "contacts-delete" pk=contact.id %}" method="POST">
   {% csrf_token %}
 
   <input type="submit" value="Yes, delete." />
-  <a href="{% url contacts-list %}">No, cancel.</a>
+  <a href="{% url "contacts-list" %}">No, cancel.</a>
 </form>

--- a/contacts/templates/edit_addresses.html
+++ b/contacts/templates/edit_addresses.html
@@ -2,7 +2,7 @@
 
 <p>Editing addresses for {{ contact }}</p>
 
-<form action="{% url contacts-edit-addresses pk=contact.id %}"
+<form action="{% url "contacts-edit-addresses" pk=contact.id %}"
       method="POST">
     {% csrf_token %}
     {{ form.management_form }}

--- a/contacts/templates/edit_contact.html
+++ b/contacts/templates/edit_contact.html
@@ -13,10 +13,10 @@
 </form>
 
 {% if contact.id %}
-<a href="{% url contacts-edit-addresses pk=contact.id %}">
+<a href="{% url "contacts-edit-addresses" pk=contact.id %}">
   Edit Addresses
 </a>
-<a href="{% url contacts-delete pk=contact.id %}">Delete</a>
+<a href="{% url "contacts-delete" pk=contact.id %}">Delete</a>
 {% endif %}
 
-<a href="{% url contacts-list %}">back to list</a>
+<a href="{% url "contacts-list" %}">back to list</a>


### PR DESCRIPTION
Django 1.5 changed the syntax for urls which means that all the examples break in Django 1.5. I Have added the quotes and have tested.

See: https://docs.djangoproject.com/en/dev/releases/1.5/
