### PR TITLE
forms.EmailField compatibility with Django 1.6

### DIFF
--- a/contacts/forms.py
+++ b/contacts/forms.py
@@ -11,7 +11,7 @@ from contacts.models import (
 class ContactForm(forms.ModelForm):
 
     confirm_email = forms.EmailField(
-        "Confirm email",
+        label="Confirm email",
         required=True,
     )
 


### PR DESCRIPTION
In Django 1.6 confirm_email = forms.EmailField("Confirm email",...) fails with error that we are trying to specify id as string.
We need to specify explicitly that "Confirm email" is label.
